### PR TITLE
Migration running

### DIFF
--- a/src/migration-runner.ts
+++ b/src/migration-runner.ts
@@ -1,0 +1,125 @@
+import { PostgresConnection } from "./postgres-connection";
+import * as fs from "fs";
+import { Migration } from "./types";
+import path from "path";
+
+export class MigrationRunner {
+  private migrationLogTablename: string = "tygress_migrations";
+
+  private migrations: Migration[] = [];
+  private migrationsMap: Map<string, Migration> = new Map();
+
+  private executedMigrations: Set<string> = new Set();
+
+  constructor(
+    private conn: PostgresConnection,
+    private migrationFolders: string[]
+  ) {}
+
+  async run() {
+    await this.ensureMigrationLogTable();
+    await Promise.all([this.loadMigrations(), this.loadExecutedMigrations()]);
+
+    const pendingMigrations = this.migrations.filter(
+      (m) => !this.executedMigrations.has(m.name)
+    );
+
+    console.log(`There are ${pendingMigrations.length} pending migrations`);
+
+    if (pendingMigrations.length < 1) {
+      return;
+    }
+
+    await this.conn.begin();
+
+    try {
+      for (const migration of pendingMigrations) {
+        await this.executeMigration(migration);
+      }
+
+      await this.conn.commit();
+    } catch (e) {
+      await this.conn.rollback();
+
+      console.log(`Error running migrations, rolling back`);
+
+      throw e;
+    }
+
+    console.log(`Migrations executed successfully`);
+  }
+
+  private async executeMigration(migration: Migration): Promise<void> {
+    console.log(`Executing ${migration.name}`);
+
+    await migration.up(this.conn);
+
+    await this.conn.query(
+      `INSERT INTO ${this.migrationLogTablename} (name, executed_at) VALUES ($1, NOW())`,
+      [migration.name]
+    );
+
+    console.log("----------------------------------------");
+  }
+
+  private async ensureMigrationLogTable(): Promise<void> {
+    const { rows } = await this.conn.query(
+      `SELECT 1 FROM pg_tables WHERE schemaname = $1 AND tablename = $2`,
+      ["public", this.migrationLogTablename]
+    );
+
+    if (rows.length > 0) {
+      return;
+    }
+
+    console.log(`Creating migration log table ${this.migrationLogTablename}`);
+
+    await this.conn.query(`
+      CREATE TABLE ${this.migrationLogTablename} (
+        name TEXT NOT NULL UNIQUE,
+        executed_at timestamptz
+      )`);
+  }
+
+  private async loadMigrations(): Promise<void> {
+    // Collect all migrations in all specified folders
+    for (const folderPath of this.migrationFolders) {
+      const filenames = fs.readdirSync(folderPath);
+
+      for (const filename of filenames) {
+        if (!["ts", "js"].includes(filename.split(".").slice(-1)[0] ?? "")) {
+          console.log(`${filename} is not a .ts or .js file, ignoring`);
+        }
+
+        const migration: Migration = await import(
+          path.join(folderPath, filename)
+        );
+
+        if (!migration.name || !migration.up || !migration.down) {
+          throw new Error(`${filename} contains an invalid migration`);
+        }
+
+        if (this.migrationsMap.has(migration.name)) {
+          throw new Error(
+            `Found duplicit migrations with name ${migration.name}`
+          );
+        }
+
+        this.migrations.push(migration);
+        this.migrationsMap.set(migration.name, migration);
+      }
+    }
+
+    this.migrations.sort((a, b) => (a.name > b.name ? -1 : 1));
+  }
+
+  private async loadExecutedMigrations(): Promise<void> {
+    this.executedMigrations = new Set(
+      (
+        await this.conn.query<{ name: string }>(
+          `SELECT name FROM ${this.migrationLogTablename}`
+        )
+      ).rows.map((e) => e.name)
+    );
+  }
+}

--- a/src/postgres-client.ts
+++ b/src/postgres-client.ts
@@ -47,17 +47,6 @@ export class PostgresClient {
     this.migrationFolders = migrationFolders;
   }
 
-  public async runMigrations(): Promise<void> {
-    if (!this.migrationFolders?.length) {
-      throw new Error(`No migrations path specified, can't run migrations`);
-    }
-
-    await this.withConnection(
-      async (conn) =>
-        await new MigrationRunner(conn, this.migrationFolders!).run()
-    );
-  }
-
   /**
     Creates an instance of an entity
     Does *not* save the entity to the database
@@ -253,6 +242,34 @@ export class PostgresClient {
     type: "QUERY" | "DML" = "QUERY"
   ): Promise<QueryResult<T>> {
     return this.withConnection((conn) => conn.query(sql, params ?? [], type));
+  }
+
+  /**
+   * Executes all pending migrations
+   */
+  public async runMigrations(): Promise<void> {
+    if (!this.migrationFolders?.length) {
+      throw new Error(`No migrations path specified, can't run migrations`);
+    }
+
+    await this.withConnection(
+      async (conn) =>
+        await new MigrationRunner(conn, this.migrationFolders!).run()
+    );
+  }
+
+  /**
+   * Rolls back the last executed migration
+   */
+  public async rollbackLastMigration(): Promise<void> {
+    if (!this.migrationFolders?.length) {
+      throw new Error(`No migrations path specified, can't run migrations`);
+    }
+
+    await this.withConnection(
+      async (conn) =>
+        await new MigrationRunner(conn, this.migrationFolders!).rollback()
+    );
   }
 
   //

--- a/src/test/client.ts
+++ b/src/test/client.ts
@@ -3,6 +3,7 @@ import { Users } from "./entities/users";
 import { Pets } from "./entities/pets";
 import { PetCategories } from "./entities/pet-categories";
 import { PetCategoriesPet } from "./entities/pet-categories-pet";
+import path from "node:path";
 
 export const TEST_DB = new PostgresClient({
   databaseUrl: process.env.DATABASE_URL!,
@@ -12,4 +13,6 @@ export const TEST_DB = new PostgresClient({
   defaultConnectionOptions: {
     collectSql: true,
   },
+
+  migrationFolders: [`${path.join(__dirname, "migrations")}`],
 });

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -15,7 +15,8 @@ export abstract class TestHelper {
 
   static async trunc(): Promise<void> {
     const res = await TEST_DB.query<{ tablename: string }>(
-      `SELECT tablename FROM pg_tables WHERE schemaname = 'public'`
+      `SELECT tablename FROM pg_tables WHERE schemaname = $1 AND tablename <> $2`,
+      ["public", "tygress_migrations"]
     );
 
     const query = res.rows

--- a/src/test/migrations/1748291362Init.ts
+++ b/src/test/migrations/1748291362Init.ts
@@ -1,9 +1,0 @@
-import { PostgresConnection } from "../../postgres-connection";
-
-export const name: string = "1748291362Init";
-
-export const up = async (conn: PostgresConnection): Promise<void> => {
-  await conn.query("SELECT 1");
-};
-
-export const down = async (conn: PostgresConnection): Promise<void> => {};

--- a/src/test/migrations/1748291362Init.ts
+++ b/src/test/migrations/1748291362Init.ts
@@ -1,0 +1,9 @@
+import { PostgresConnection } from "../../postgres-connection";
+
+export const name: string = "1748291362Init";
+
+export const up = async (conn: PostgresConnection): Promise<void> => {
+  await conn.query("SELECT 1");
+};
+
+export const down = async (conn: PostgresConnection): Promise<void> => {};

--- a/src/test/migrations/1748291362Test.ts
+++ b/src/test/migrations/1748291362Test.ts
@@ -1,0 +1,11 @@
+import { PostgresConnection } from "../../postgres-connection";
+
+export const name: string = "1748291362Test";
+
+export const up = async (conn: PostgresConnection): Promise<void> => {
+  await conn.query("CREATE TABLE tygress_migration_test (id INT)");
+};
+
+export const down = async (conn: PostgresConnection): Promise<void> => {
+  await conn.query("DROP TABLE tygress_migration_test");
+};

--- a/src/test/tests/migrations.test.ts
+++ b/src/test/tests/migrations.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "vitest";
+import { TEST_DB } from "../client";
+
+describe("migrations", async () => {
+  test("run", async () => {
+    await TEST_DB.runMigrations();
+
+    expect(
+      (
+        await TEST_DB.query(
+          `SELECT 1 FROM pg_tables WHERE schemaname = $1 AND tablename = $2`,
+          ["public", "tygress_migration_test"]
+        )
+      ).rows
+    ).toHaveLength(1);
+
+    expect(
+      (await TEST_DB.query("SELECT name FROM tygress_migrations")).rows[0]?.name
+    ).toBe("1748291362Test");
+  });
+
+  test("rollback", async () => {
+    await TEST_DB.rollbackLastMigration();
+
+    expect(
+      (
+        await TEST_DB.query(
+          `SELECT 1 FROM pg_tables WHERE schemaname = $1 AND tablename = $2`,
+          ["public", "tygress_migration_test"]
+        )
+      ).rows
+    ).toHaveLength(0);
+
+    expect(
+      (await TEST_DB.query("SELECT name FROM tygress_migrations")).rows
+    ).toHaveLength(0);
+  });
+});

--- a/src/types/connection-settings/postgres-client-options.ts
+++ b/src/types/connection-settings/postgres-client-options.ts
@@ -20,4 +20,7 @@ export type PostgresClientOptions = {
   queryLogLevel?: QueryLogLevel;
 
   entities: AnEntity[];
+
+  // Path to file(s) containing migrations
+  migrationFolders?: string[];
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,5 +11,6 @@ export { SelectTargetArgs } from "./select-target-args";
 export { SelectQueryArgs } from "./select-query-args";
 export { SelectQueryTarget } from "./select-query-target";
 export { ClassArg } from "./class-arg";
+export { Migration } from "./migration";
 
 export * from "./conditions";

--- a/src/types/migration.ts
+++ b/src/types/migration.ts
@@ -1,0 +1,9 @@
+import { PostgresConnection } from "../postgres-connection";
+
+export type Migration = {
+  name: string;
+
+  up: (conn: PostgresConnection) => Promise<void>;
+
+  down: (conn: PostgresConnection) => Promise<void>;
+};


### PR DESCRIPTION
Adds support for running migrations and rolling back migrations.

Migrations should be defined in files in folders specified by the user. Migrations are executed in ascending order by name. Each executed migration is logged in a table in the database, this log is then possibly used for rolling back migrations in the order they were executed in.