### PR TITLE
Lazily load entities in relation decorators

### DIFF
--- a/src/decorators/many-to-one.ts
+++ b/src/decorators/many-to-one.ts
@@ -1,9 +1,9 @@
 import { Relation } from "../enums";
 import { METADATA_STORE } from "../metadata/metadata-store";
-import { AnEntity, Entity } from "../types/entity";
+import { AnEntity } from "../types/entity";
 
 export const ManyToOne = <Foreign extends Object, Primary extends AnEntity>(
-  primary: Primary,
+  primaryFn: () => Primary,
   primaryField: keyof InstanceType<Primary>,
   foreignKey: keyof Foreign,
   primaryKey?: keyof InstanceType<Primary>
@@ -12,11 +12,11 @@ export const ManyToOne = <Foreign extends Object, Primary extends AnEntity>(
     METADATA_STORE.addRelation({
       type: Relation.MANY_TO_ONE,
 
-      foreign: target.constructor as Entity<unknown>,
+      foreign: () => target.constructor as AnEntity,
       foreignField: propertyName,
       foreignKey: foreignKey?.toString(),
 
-      primary,
+      primary: primaryFn,
       primaryField: primaryField.toString(),
       primaryKey: primaryKey?.toString() ?? "id",
     });

--- a/src/decorators/one-to-many.ts
+++ b/src/decorators/one-to-many.ts
@@ -1,17 +1,17 @@
 import { Relation } from "../enums";
 import { METADATA_STORE } from "../metadata/metadata-store";
-import { Entity } from "../types/entity";
+import { AnEntity } from "../types/entity";
 
-export const OneToMany = <Foreign extends Entity<unknown>>(
-  foreign: Foreign,
+export const OneToMany = <Foreign extends AnEntity>(
+  foreignFn: () => Foreign,
   foreignField: keyof InstanceType<Foreign>
 ) => {
   return function (target: Object, propertyName: string) {
     METADATA_STORE.addRelation({
       type: Relation.ONE_TO_MANY,
-      foreign,
+      foreign: foreignFn,
       foreignField: foreignField.toString(),
-      primary: target.constructor as Entity<unknown>,
+      primary: () => target.constructor as AnEntity,
       primaryField: propertyName,
     });
   };

--- a/src/factories/relation-metadata.ts
+++ b/src/factories/relation-metadata.ts
@@ -16,11 +16,11 @@ export abstract class RelationMetadataFactory {
 
     e.type = type;
 
-    e.primary = primary;
+    e.primary = primary();
     e.primaryField = primaryField;
     e.primaryKey = primaryKey ?? "id";
 
-    e.foreign = foreign;
+    e.foreign = foreign();
     e.foreignField = foreignField;
     e.foreignKey = foreignKey ?? fieldNameToColumName(foreignField) + "_id";
 

--- a/src/factories/table-metadata.ts
+++ b/src/factories/table-metadata.ts
@@ -1,4 +1,4 @@
-import { ColumnMetadata, RelationMetadata } from "../metadata";
+import { ColumnMetadata } from "../metadata";
 import { TableMetadata } from "../metadata/table-metadata";
 import { UniqueConstraintMetadata } from "../metadata/unique-constraint";
 import { AnEntity } from "../types";
@@ -8,9 +8,7 @@ export abstract class TableMetadataFactory {
   public static create(
     { tablename, klass, schemaname }: TableMetadataArgs,
     columns: ColumnMetadata[],
-    relations: RelationMetadata[],
-    uniqueConstraint: UniqueConstraintMetadata<AnEntity>,
-    fields: string[]
+    uniqueConstraint: UniqueConstraintMetadata<AnEntity>
   ): TableMetadata {
     const e = new TableMetadata();
 
@@ -28,43 +26,7 @@ export abstract class TableMetadataFactory {
       column.table = e;
     }
 
-    for (const relation of relations) {
-      if (relation.foreign === klass) {
-        // Ensure column referenced by relation exists
-        if (!e.columnsMap.get(relation.foreignKey)) {
-          throw new Error(
-            `No column found for entity ${e}, field name ${relation.foreignKey}`
-          );
-        }
-
-        e.relations.set(relation.foreignField, relation);
-      } else if (relation.primary === klass) {
-        // Ensure column referenced by relation exists
-        if (!e.columnsMap.get(relation.primaryKey)) {
-          throw new Error(
-            `No column found for entity ${e}, field name ${relation.primaryKey}`
-          );
-        }
-
-        e.relations.set(relation.primaryField, relation);
-      } else {
-        throw new Error(
-          `Tried to register relation that belongs to ${relation.primary} and ${relation.foreign} to ${klass}`
-        );
-      }
-    }
-
     e.primaryKey = uniqueConstraint;
-
-    // Figure out which fields are typed as arrays
-    const instance = new klass();
-    for (const field of fields) {
-      if (
-        Reflect.getMetadata("design:type", instance as any, field) === Array
-      ) {
-        e.arrayFields.add(field);
-      }
-    }
 
     return e;
   }

--- a/src/metadata/metadata-store.ts
+++ b/src/metadata/metadata-store.ts
@@ -13,12 +13,12 @@ import {
   TableMetadataArgs,
   UniqueConstraintMetadataArgs,
 } from "../types/create-args";
-import { AnEntity, Entity } from "../types";
+import { AnEntity } from "../types";
 import { UniqueConstraintMetadata } from "./unique-constraint";
 
 class MetadataStore {
-  public tables = new Map<Entity<unknown>, TableMetadata>();
-  public columns = new Map<Entity<unknown>, ColumnMetadata[]>();
+  public tables = new Map<AnEntity, TableMetadata>();
+  public columns = new Map<AnEntity, ColumnMetadata[]>();
 
   public relations: RelationMetadata[] = [];
 
@@ -30,11 +30,13 @@ class MetadataStore {
   // All fields which are decorated by our decorators
   public fields = new Map<AnEntity, string[]>();
 
+  private relationArgs: RelationMetadataArgs[] = [];
+
   //
   // Getters
   //
-  public getTable<T extends Entity<unknown>>(table: T): TableMetadata {
-    const res = this.tables.get(table as Entity<unknown>);
+  public getTable<T extends AnEntity>(table: T): TableMetadata {
+    const res = this.tables.get(table as AnEntity);
     if (!res) {
       throw new Error(`No metadata found for ${table}`);
     }
@@ -104,11 +106,7 @@ class MetadataStore {
     const metadata = TableMetadataFactory.create(
       args,
       columns,
-      this.relations.filter(
-        (e) => e.primary === args.klass || e.foreign === args.klass
-      ),
-      uniqueConstraint,
-      this.fields.get(args.klass) ?? []
+      uniqueConstraint
     );
 
     this.tables.set(metadata.klass, metadata);
@@ -148,56 +146,108 @@ class MetadataStore {
   }
 
   public addRelation(args: RelationMetadataArgs) {
-    const relation = RelationMetadataFactory.create(args);
+    this.relationArgs.push(args);
+  }
 
-    // Inserting OneToMany so current relation is the primary side
-    // Back-fill the primary class to the inverse side of the currently inserted relation
-    if (relation.type === Relation.ONE_TO_MANY && relation.foreign) {
-      const inverseRelation = this.relations.find(
-        (e) =>
-          e.type === Relation.MANY_TO_ONE &&
-          e.foreign === relation.foreign &&
-          e.primaryField === relation.primaryField &&
-          e.foreignField === relation.foreignField
-      );
+  public finalize(_entities: AnEntity[]): void {
+    this.createRelations();
 
-      if (inverseRelation) {
-        if (!inverseRelation.primary) {
-          inverseRelation.primary = relation.primary;
+    this.registerRelationsToEntities();
+
+    this.registerArrayFields();
+  }
+
+  // Creates relation metadata from relation args
+  private createRelations(): void {
+    for (const args of this.relationArgs) {
+      const relation = RelationMetadataFactory.create(args);
+
+      // Inserting OneToMany so current relation is the primary side
+      // Back-fill the primary class to the inverse side of the currently inserted relation
+      if (relation.type === Relation.ONE_TO_MANY && relation.foreign) {
+        const inverseRelation = this.relations.find(
+          (e) =>
+            e.type === Relation.MANY_TO_ONE &&
+            e.foreign === relation.foreign &&
+            e.primaryField === relation.primaryField &&
+            e.foreignField === relation.foreignField
+        );
+
+        if (inverseRelation) {
+          if (!inverseRelation.primary) {
+            inverseRelation.primary = relation.primary;
+          }
+
+          relation.primaryKey = inverseRelation.primaryKey;
+          relation.foreignKey = inverseRelation.foreignKey;
         }
+      }
 
-        relation.primaryKey = inverseRelation.primaryKey;
-        relation.foreignKey = inverseRelation.foreignKey;
+      // Inserting ManyToOne so current relation is the foreign side
+      // Back-fill the foreign class to the inverse side of the currently inserted relation
+      if (relation.type === Relation.MANY_TO_ONE && relation.primary) {
+        const inverseRelation = this.relations.find(
+          (e) =>
+            e.type === Relation.ONE_TO_MANY &&
+            e.primary === relation.primary &&
+            e.primaryField === relation.primaryField &&
+            e.foreignField === relation.foreignField
+        );
+
+        if (inverseRelation) {
+          if (!inverseRelation.foreign) {
+            inverseRelation.foreign = relation.foreign;
+          }
+
+          inverseRelation.foreignKey = relation.foreignKey;
+          inverseRelation.primaryKey = relation.primaryKey;
+        }
+      }
+
+      // Finally insert new relation into the array
+      this.relations.push(relation);
+
+      // Log both fiels from the relation
+      this.addField(args.foreign(), args.foreignField);
+      this.addField(args.primary(), args.primaryField);
+    }
+  }
+
+  // Adds info about relations to entity metadata
+  private registerRelationsToEntities(): void {
+    for (const relation of this.relations) {
+      // Register relation to foreign tables meta
+      const foreignMeta = this.getTable(relation.foreign);
+      if (!foreignMeta.columnsMap.get(relation.foreignKey)) {
+        throw new Error(
+          `No column found for entity ${foreignMeta.klass.name}, field name ${relation.foreignKey}`
+        );
+      }
+      foreignMeta.relations.set(relation.foreignField, relation);
+
+      // Register relation to primary tables meta
+      const primaryMeta = this.getTable(relation.primary);
+      if (!primaryMeta.columnsMap.get(relation.primaryKey)) {
+        throw new Error(
+          `No column found for entity ${primaryMeta.klass.name}, field name ${relation.primaryKey}`
+        );
+      }
+      primaryMeta.relations.set(relation.primaryField, relation);
+    }
+  }
+
+  // Adds info about which fields are arrays to entity metadata
+  private registerArrayFields(): void {
+    for (const entity of this.tables.values()) {
+      const instance = new entity.klass();
+      for (const field of this.fields.get(entity.klass) ?? []) {
+        if (
+          Reflect.getMetadata("design:type", instance as any, field) === Array
+        ) {
+          entity.arrayFields.add(field);
+        }
       }
     }
-
-    // Inserting ManyToOne so current relation is the foreign side
-    // Back-fill the foreign class to the inverse side of the currently inserted relation
-    if (relation.type === Relation.MANY_TO_ONE && relation.primary) {
-      const inverseRelation = this.relations.find(
-        (e) =>
-          e.type === Relation.ONE_TO_MANY &&
-          e.primary === relation.primary &&
-          e.primaryField === relation.primaryField &&
-          e.foreignField === relation.foreignField
-      );
-
-      if (inverseRelation) {
-        if (!inverseRelation.foreign) {
-          inverseRelation.foreign = relation.foreign;
-        }
-
-        inverseRelation.foreignKey = relation.foreignKey;
-        inverseRelation.primaryKey = relation.primaryKey;
-      }
-    }
-
-    // Finally insert new relation into the array
-    this.relations.push(relation);
-
-    // Log both fiels from the relation
-    this.addField(args.foreign, args.foreignField);
-    this.addField(args.primary, args.primaryField);
   }
 }
 

--- a/src/postgres-client.ts
+++ b/src/postgres-client.ts
@@ -16,6 +16,7 @@ import { QueryLogLevel } from "./enums";
 import { FlattenRawSelectSources } from "./types/query-builder";
 import { MigrationRunner } from "./migration-runner";
 import { MigrationGenerator } from "./migration-generator";
+import { METADATA_STORE } from "./metadata";
 
 export class PostgresClient {
   private pool: Pool;
@@ -35,6 +36,8 @@ export class PostgresClient {
     entities,
     migrationFolders,
   }: PostgresClientOptions) {
+    METADATA_STORE.finalize(entities);
+
     this.pool = new Pool({
       connectionString: databaseUrl,
       ssl,

--- a/src/test/entities/pet-categories-pet.ts
+++ b/src/test/entities/pet-categories-pet.ts
@@ -13,9 +13,9 @@ export class PetCategoriesPet extends TygressEntity {
   @Column("pet_category_id")
   petCategoryId: string;
 
-  @ManyToOne(Pets, "categories", "petId")
+  @ManyToOne(() => Pets, "categories", "petId")
   pet: Pets;
 
-  @ManyToOne(PetCategories, "pets", "petCategoryId")
+  @ManyToOne(() => PetCategories, "pets", "petCategoryId")
   category: PetCategories;
 }

--- a/src/test/entities/pet-categories.ts
+++ b/src/test/entities/pet-categories.ts
@@ -9,6 +9,6 @@ export class PetCategories extends TygressEntity {
   @Column("name")
   name: string;
 
-  @OneToMany(PetCategoriesPet, "category")
+  @OneToMany(() => PetCategoriesPet, "category")
   pets: PetCategoriesPet[];
 }

--- a/src/test/entities/pets.ts
+++ b/src/test/entities/pets.ts
@@ -29,9 +29,9 @@ export class Pets extends TygressEntity {
 
   // RELATIONS
 
-  @ManyToOne(Users, "pets", "userId")
+  @ManyToOne(() => Users, "pets", "userId")
   user: Users;
 
-  @OneToMany(PetCategoriesPet, "pet")
+  @OneToMany(() => PetCategoriesPet, "pet")
   categories: PetCategoriesPet[];
 }

--- a/src/test/entities/users.ts
+++ b/src/test/entities/users.ts
@@ -18,6 +18,6 @@ export class Users extends TygressEntity {
   @Column("birthdate")
   birthdate: Date | null;
 
-  @OneToMany(Pets, "user")
+  @OneToMany(() => Pets, "user")
   pets: Pets[];
 }

--- a/src/types/create-args/relation-metadata.ts
+++ b/src/types/create-args/relation-metadata.ts
@@ -4,11 +4,11 @@ import { AnEntity } from "../entity";
 export type RelationMetadataArgs = {
   type: Relation;
 
-  foreign: AnEntity;
+  foreign: () => AnEntity;
   foreignField: string;
   foreignKey?: string;
 
-  primary: AnEntity;
+  primary: () => AnEntity;
   primaryField: string;
   primaryKey?: string;
 };


### PR DESCRIPTION
 - Take `() => EntityName` as an argument instead of `EntityName`
 - Only resolve the actual entity once we are sure its fully loaded to prevent issues with circular dependencies
   - This is done by adding a `finalize` step to `METADATA_STORE`
 - Register relations and array fields to entity meta in `METADATA_STORE` instead of `TableMetadataFactory`