### PR TITLE
Convenience methods

### DIFF
--- a/src/postgres-client.ts
+++ b/src/postgres-client.ts
@@ -190,7 +190,7 @@ export class PostgresClient {
   }
 
   /**
-   * Executes the same query as `select`, returning the first entity
+   * Executes the same query as `select`, returning the first entity or null
    *
    * This does **not** add a `LIMIT 1` to your SQL query so the whole result will be retrieved
    */

--- a/src/postgres-client.ts
+++ b/src/postgres-client.ts
@@ -212,7 +212,7 @@ export class PostgresClient {
     UpdateFields extends keyof InstanceType<T>
   >(
     entity: T,
-    values: InsertPayload<T>[],
+    values: InsertPayload<T>[] | InsertPayload<T>,
     options?: InsertOptions<T, ReturnedFields, ConflictFields, UpdateFields>
   ): Promise<InsertResult<T>> {
     return this.withConnection((conn) =>

--- a/src/postgres-client.ts
+++ b/src/postgres-client.ts
@@ -190,6 +190,18 @@ export class PostgresClient {
   }
 
   /**
+   * Executes the same query as `select`, returning the first entity
+   *
+   * This does **not** add a `LIMIT 1` to your SQL query so the whole result will be retrieved
+   */
+  public async selectOne<T extends AnEntity>(
+    entity: T,
+    args: SelectArgs<InstanceType<T>>
+  ): Promise<InstanceType<T> | null> {
+    return (await this.select(entity, args))[0] ?? null;
+  }
+
+  /**
     Runs an INSERT statement using the provided values
     Optionally returns inserted rows as entities
   */

--- a/src/postgres-connection.ts
+++ b/src/postgres-connection.ts
@@ -68,7 +68,7 @@ export class PostgresConnection {
   }
 
   /**
-   * Executes the same query as `select`, returning the first entity
+   * Executes the same query as `select`, returning the first entity or null
    *
    * This does **not** add a `LIMIT 1` to your SQL query so the whole result will be retrieved
    */

--- a/src/postgres-connection.ts
+++ b/src/postgres-connection.ts
@@ -92,7 +92,7 @@ export class PostgresConnection {
     UpdateFields extends keyof InstanceType<T>
   >(
     entity: T,
-    values: InsertPayload<T>[],
+    values: InsertPayload<T>[] | InsertPayload<T>,
     options?: InsertOptions<T, ReturnedFields, ConflictFields, UpdateFields>
   ): Promise<InsertResult<T>> {
     this.ensureReadiness();

--- a/src/postgres-connection.ts
+++ b/src/postgres-connection.ts
@@ -68,6 +68,20 @@ export class PostgresConnection {
   }
 
   /**
+   * Executes the same query as `select`, returning the first entity
+   *
+   * This does **not** add a `LIMIT 1` to your SQL query so the whole result will be retrieved
+   */
+  public async selectOne<T extends AnEntity>(
+    entity: T,
+    args: SelectArgs<InstanceType<T>>
+  ): Promise<InstanceType<T> | null> {
+    this.ensureReadiness();
+
+    return (await this.select(entity, args))[0] ?? null;
+  }
+
+  /**
     Runs an INSERT statement using the provided values
     Optionally returns inserted rows as entities
   */

--- a/src/query-builder.ts
+++ b/src/query-builder.ts
@@ -2322,6 +2322,15 @@ export class QueryBuilder<G extends QueryBuilderGenerics> {
   }
 
   /**
+   * Executes the query and returns the first entity or null
+   *
+   * This does **not** add a `LIMIT 1` to the query so the whole result will be retrieved
+   */
+  public async getOneEntity(): Promise<InstanceType<G["RootEntity"]> | null> {
+    return (await this.getEntities())[0] ?? null;
+  }
+
+  /**
    * Executes the query and returns the raw result the way it comes from the pg client
    */
   public async getRaw(): Promise<Pretty<G["ExplicitSelects"]>[]> {
@@ -2333,5 +2342,14 @@ export class QueryBuilder<G extends QueryBuilderGenerics> {
           (await conn.query(query.sql, query.params)).rows
         ) as any
     );
+  }
+
+  /**
+   * Executes the query and returns the first row or null
+   *
+   * This does **not** add a `LIMIT 1` to the query so the whole result will be retrieved
+   */
+  public async getOneRaw(): Promise<Pretty<G["ExplicitSelects"]> | null> {
+    return (await this.getRaw())[0] ?? null;
   }
 }

--- a/src/repository/repository.ts
+++ b/src/repository/repository.ts
@@ -19,7 +19,7 @@ import {
   SelectTargetSqlBuilderFactory,
   TableIdentifierSqlBuilderFactory,
 } from "../factories";
-import { entityNameToAlias } from "../utils";
+import { arrayify, entityNameToAlias } from "../utils";
 import {
   ComparisonSqlBuilder,
   ParamBuilder,
@@ -46,7 +46,7 @@ export abstract class Repository {
   >(
     client: PostgresConnection,
     entity: T,
-    values: InsertPayload<T>[],
+    values: InsertPayload<T>[] | InsertPayload<T>,
     {
       returning,
       onConflict,
@@ -56,9 +56,11 @@ export abstract class Repository {
   ): Promise<InsertResult<T>> {
     const tableMeta = METADATA_STORE.getTable(entity);
 
+    const payload = arrayify(values);
+
     // Collect all fields that have a value provided in the input
     const insertedFields = new Set<string>();
-    for (const value of values) {
+    for (const value of payload) {
       for (const key of Object.keys(value)) {
         insertedFields.add(key);
       }
@@ -105,7 +107,7 @@ export abstract class Repository {
     //
     const insert = new InsertSqlBuilder({
       entity: tableMeta,
-      values,
+      values: payload,
       columns,
       paramBuilder: new ParamBuilder(),
 

--- a/src/test/tests/query-builder.test.ts
+++ b/src/test/tests/query-builder.test.ts
@@ -1,5 +1,5 @@
 import { TEST_DB } from "../client";
-import { beforeAll, describe, expect, test } from "vitest";
+import { describe, expect, test } from "vitest";
 import { Users } from "../entities/users";
 import { TestHelper } from "../helpers";
 import { Pets } from "../entities/pets";
@@ -648,5 +648,39 @@ describe("QueryBuilder", async () => {
       .getRaw();
 
     expect(res2).toEqual([]);
+  });
+
+  describe("getOneEntity", async () => {
+    test("basic", async () => {
+      const res = await TEST_DB.queryBuilder("u", Users).getOneEntity();
+
+      expect(res).toStrictEqual(user1);
+    });
+
+    test("no result", async () => {
+      const res = await TEST_DB.queryBuilder("u", Users)
+        .where("1=0")
+        .getOneEntity();
+
+      expect(res).toStrictEqual(null);
+    });
+  });
+
+  describe("getOneRaw", async () => {
+    test("basic", async () => {
+      const res = await TEST_DB.queryBuilder("u", Users)
+        .setSelect("u", "id", "id")
+        .getOneRaw();
+
+      expect(res).toStrictEqual({ id: user1.id });
+    });
+
+    test("no result", async () => {
+      const res = await TEST_DB.queryBuilder("u", Users)
+        .where("1=0")
+        .getOneRaw();
+
+      expect(res).toStrictEqual(null);
+    });
   });
 });

--- a/src/test/tests/select.test.ts
+++ b/src/test/tests/select.test.ts
@@ -221,4 +221,46 @@ describe("select", async () => {
       expect(res).toStrictEqual([]);
     });
   });
+
+  describe("selectOne", async () => {
+    test("basic", async () => {
+      const res = await TEST_DB.selectOne(Users, {});
+
+      expect(res).toStrictEqual(user1);
+    });
+
+    test("order", async () => {
+      const res = await TEST_DB.selectOne(Users, {
+        order: {
+          username: "ASC",
+        },
+      });
+
+      expect(res).toStrictEqual(user2);
+    });
+
+    test("join", async () => {
+      const res = await TEST_DB.selectOne(Users, {
+        joins: {
+          pets: true,
+        },
+        order: {
+          username: "ASC",
+          pets: {
+            name: "ASC",
+          },
+        },
+      });
+
+      expect(res!.pets).toStrictEqual([]);
+    });
+
+    test("no result", async () => {
+      const res = await TEST_DB.selectOne(Users, {
+        offset: 10,
+      });
+
+      expect(res).toStrictEqual(null);
+    });
+  });
 });

--- a/src/utils/arrayify.ts
+++ b/src/utils/arrayify.ts
@@ -1,0 +1,2 @@
+export const arrayify = <T>(val: T[] | T): T[] =>
+  Array.isArray(val) ? val : [val];

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -9,3 +9,4 @@ export { parsePgColumnDefault } from "./parse-column-default";
 export { fkActionsEqual } from "./fk-actions-equal";
 export { FKActionConverter } from "./fk-action-converter";
 export { STYLE } from "./tty-styles";
+export { arrayify } from "./arrayify";


### PR DESCRIPTION
- `selectOne` to get first entity from a `select` result
- `getOneEntity` to get first entity from query builder query
- `getOneRaw` to get first raw row from query builder query