### PR TITLE
Inline constant builder

### DIFF
--- a/src/sql-builders/pseudo-sql-replacer.ts
+++ b/src/sql-builders/pseudo-sql-replacer.ts
@@ -13,7 +13,7 @@ type Replacement = {
 export abstract class PseudoSQLReplacer {
   // Takes in SQL snippet which uses actual aliases from a query and fieldNames from an entity class
   // Returns the snippet with proper quotation and fieldNames replaced by column_names
-  // Ignores any input in parentheses
+  // Ignores any input in quotes
   public static replaceIdentifiers<G extends QueryBuilderGenerics>(
     input: string,
     sourcesContext: SourcesContext<G>

--- a/src/test/tests/constant-serializer.test.ts
+++ b/src/test/tests/constant-serializer.test.ts
@@ -6,16 +6,32 @@ describe("ConstantSerializer", () => {
     expect(ConstantSerializer.serialize(i)).toEqual(o);
 
   test("primitives", () => {
-    e(123, `E'123'`);
-    e(123.4, `E'123.4'`);
+    e(123, `'123'`);
+    e(123.4, `'123.4'`);
+    e(null, "NULL");
+    e(undefined, "NULL");
     e(true, "TRUE");
     e(false, "FALSE");
-    e(new Date("2020-01-01"), `E'2020-01-01T00:00:00.000Z'`);
-    e(Buffer.from("asdf"), "E'61736466'");
+    e("asdf", `'asdf'`);
+    e(`m'lady`, `'m''lady'`);
+    e(new Date("2020-01-01"), `'2020-01-01T00:00:00.000Z'`);
+    e(Buffer.from("asdf"), "'\\x61736466'");
   });
 
   test("objects", () => {
-    e([], `E'{}'`);
-    e([123], `E'{"123"}'`);
+    e([], `'{}'`);
+    e([123], `'{"123"}'`);
+    e(["crazy", "hamburger"], `'{"crazy", "hamburger"}'`);
+    e([`m'lady`], `'{"m''lady"}'`);
+    e(
+      [Buffer.from("asdf"), Buffer.from("meow")],
+      `'{"\\\\x61736466", "\\\\x6d656f77"}'`
+    );
+    e([null, undefined], `'{NULL, NULL}'`);
+    e(
+      [new Date("2020-01-01"), new Date("2020-01-01")],
+      `'{"2020-01-01T00:00:00.000Z", "2020-01-01T00:00:00.000Z"}'`
+    );
+    e([`m'eow`, `crazy "hamburger"`], `'{"m''eow", "crazy \\"hamburger\\""}'`);
   });
 });

--- a/src/test/tests/constant-serializer.test.ts
+++ b/src/test/tests/constant-serializer.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "vitest";
+import { ConstantSerializer } from "../../utils";
+
+describe("ConstantSerializer", () => {
+  const e = (i: any, o: string) =>
+    expect(ConstantSerializer.serialize(i)).toEqual(o);
+
+  test("primitives", () => {
+    e(123, `E'123'`);
+    e(123.4, `E'123.4'`);
+    e(true, "TRUE");
+    e(false, "FALSE");
+    e(new Date("2020-01-01"), `E'2020-01-01T00:00:00.000Z'`);
+    e(Buffer.from("asdf"), "E'61736466'");
+  });
+
+  test("objects", () => {
+    e([], `E'{}'`);
+    e([123], `E'{"123"}'`);
+  });
+});

--- a/src/test/tests/constant-serializer.test.ts
+++ b/src/test/tests/constant-serializer.test.ts
@@ -32,6 +32,9 @@ describe("ConstantSerializer", () => {
       [new Date("2020-01-01"), new Date("2020-01-01")],
       `'{"2020-01-01T00:00:00.000Z", "2020-01-01T00:00:00.000Z"}'`
     );
-    e([`m'eow`, `crazy "hamburger"`], `'{"m''eow", "crazy \\"hamburger\\""}'`);
+    e(
+      [[`m'eow`, `crazy "hamburger"`]],
+      `'{{"m''eow", "crazy \\"hamburger\\""}}'`
+    );
   });
 });

--- a/src/utils/constant-serializer.ts
+++ b/src/utils/constant-serializer.ts
@@ -1,0 +1,59 @@
+import { dQ } from "./double-quote";
+import { isNull } from "./is-null";
+
+export abstract class ConstantSerializer {
+  static serialize(val: any): string {
+    if (typeof val === "function") {
+      throw new Error(`Can't serialize a function as Postgres input`);
+    }
+
+    if (isNull(val)) {
+      return "NULL";
+    }
+
+    // TRUE or FALSE literals should not be escaped so handling them in this function
+    if (typeof val === "boolean") {
+      return val ? "TRUE" : "FALSE";
+    }
+
+    // Serialize value, turn all 's into ''s and \s into \\s
+    return `E'${this._serialize(val).replace(/['\\]/g, (m) => m + m)}'`;
+  }
+
+  private static _serialize(val: any): string {
+    if (typeof val === "function") {
+      throw new Error(`Can't serialize a function as Postgres input`);
+    }
+
+    if (isNull(val)) {
+      return "NULL";
+    }
+
+    switch (typeof val) {
+      case "boolean":
+        return val ? "TRUE" : "FALSE";
+      case "object":
+        return this.serializeObject(val);
+      default:
+        return val.toString();
+    }
+  }
+
+  private static serializeObject(val: object): string {
+    if (val instanceof Date) {
+      return val.toISOString();
+    }
+
+    if (val instanceof Buffer) {
+      return val.toString("hex");
+    }
+
+    if (Array.isArray(val)) {
+      const childValues = val.map((e) => dQ(this._serialize(e)));
+
+      return `{${childValues.join(", ")}}`;
+    }
+
+    return JSON.stringify(val);
+  }
+}

--- a/src/utils/constant-serializer.ts
+++ b/src/utils/constant-serializer.ts
@@ -4,12 +4,12 @@ import { isNull } from "./is-null";
 // Serializes a value int Postgres input
 export abstract class ConstantSerializer {
   // These values should not be put in "s or 's
-  private static UNESCAPEABLE_VALUES: string[] = ["NULL", "TRUE", "FALSE"];
+  private static INESCAPABLE_VALUES: string[] = ["NULL", "TRUE", "FALSE"];
 
   static serialize(val: any): string {
     const serialized = this._serialize(val);
 
-    if (this.UNESCAPEABLE_VALUES.includes(serialized)) {
+    if (this.INESCAPABLE_VALUES.includes(serialized)) {
       return serialized;
     }
 
@@ -58,7 +58,7 @@ export abstract class ConstantSerializer {
 
   // By default array elements should be enclosed in "s but there are some exceptions
   private static escapeArrayElement(e: string): string {
-    if (this.UNESCAPEABLE_VALUES.includes(e)) {
+    if (this.INESCAPABLE_VALUES.includes(e)) {
       return e;
     }
 

--- a/src/utils/constant-serializer.ts
+++ b/src/utils/constant-serializer.ts
@@ -1,6 +1,7 @@
 import { dQ } from "./double-quote";
 import { isNull } from "./is-null";
 
+// Serializes a value int Postgres input
 export abstract class ConstantSerializer {
   // These values should not be put in "s or 's
   private static UNESCAPEABLE_VALUES: string[] = ["NULL", "TRUE", "FALSE"];
@@ -55,6 +56,7 @@ export abstract class ConstantSerializer {
     return JSON.stringify(val);
   }
 
+  // By default array elements should be enclosed in "s but there are some exceptions
   private static escapeArrayElement(e: string): string {
     if (this.UNESCAPEABLE_VALUES.includes(e)) {
       return e;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -10,3 +10,4 @@ export { fkActionsEqual } from "./fk-actions-equal";
 export { FKActionConverter } from "./fk-action-converter";
 export { STYLE } from "./tty-styles";
 export { arrayify } from "./arrayify";
+export { ConstantSerializer } from "./constant-serializer";


### PR DESCRIPTION
Class to serialize constants into Postgres input. The goal is to use this for constant inputs in generated DDL statements. Queries and DML use query params so this logic won't affect those